### PR TITLE
configure all CIDRs and fix image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,27 @@ clean:
 	-$(QUIET) for i in $(SUBDIRS); do $(MAKE) $(SUBMAKEOPTS) -C $$i clean; done
 
 force :;
+
+# get image name from directory we're building
+IMAGE_NAME=nat64
+# docker image registry, default to upstream
+REGISTRY?=gcr.io/k8s-staging-networking
+# tag based on date-sha
+TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
+# the full image tag
+NAT64_IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
+PLATFORMS?=linux/amd64,linux/arm64
+
+image-build:
+	docker buildx build . \
+		--tag="${NAT64_IMAGE}" \
+		--load
+
+image-push:
+	docker buildx build . \
+		--platform="${PLATFORMS}" \
+		--tag="${NAT64_IMAGE}" \
+		--push
+
+.PHONY: release # Build a multi-arch docker image
+release: build image-push

--- a/README.md
+++ b/README.md
@@ -96,18 +96,8 @@ Just do `kubectl apply -f https://raw.githubusercontent.com/aojea/nat64/main/ins
 
 Assuming you have checked out the repo and you are already in the repo folder
 
-1. Install kind cluster with IPv6 only
-
-```yaml
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-networking:
-  ipFamily: ipv6
-nodes:
-- role: control-plane
-- role: worker
-```
+1. Install kind cluster with IPv6 only using `kind-ipv6.yaml` located in the
+   root directory of the repository
 
 ```sh
 kind create cluster --name ipv6 --config kind-ipv6.yaml
@@ -116,13 +106,15 @@ kind create cluster --name ipv6 --config kind-ipv6.yaml
 1. Build project (it already compiles the eBPF code too)
 
 ```sh
-docker build . -t aojea/nat64:v0.1.0
+make image-build
+# save image tag
+IMAGE_TAG=...
 ```
 
 1. Preload the image in the kind cluster we just created
 
 ```sh
-kind load docker-image aojea/nat64:v0.1.0 --name ipv6
+kind load docker-image ${IMAGE_TAG} --name ipv6
 ```
 
 1. Install the nat64 daemonset
@@ -156,7 +148,7 @@ This is far to be complete, features and suggestions are welcome:
 - [ ] metrics: number of NAT64 translations: connection, packets, protocol, ...
 - [ ] Right now the algorithm to map 6 to 4 is very simple, use the latest digit from the Pod IPv6 address, this limits us to 254 connection, is that enough?
 - [x] TCP and UDP checksum (fixed by @siwiutki)
-- [ ] ICMP
+- [x] ICMP
 - [ ] Testing, testing, ....
 
 ## Contributors

--- a/bpf/include/lib/config.h
+++ b/bpf/include/lib/config.h
@@ -17,10 +17,22 @@ limitations under the License.
 #pragma once
 
 // all constants here are overriden from user-space level
+volatile const uint32_t IPV4_NAT_PREFIX = 0;
+volatile const uint32_t IPV4_NAT_MASK = 0;
+
+volatile const uint32_t IPV6_NAT_PREFIX_0 = 0;
+volatile const uint32_t IPV6_NAT_PREFIX_1 = 0;
+volatile const uint32_t IPV6_NAT_PREFIX_2 = 0;
+
+volatile const uint32_t IPV6_NAT_MASK_0 = 0;
+volatile const uint32_t IPV6_NAT_MASK_1 = 0;
+volatile const uint32_t IPV6_NAT_MASK_2 = 0;
+
 volatile const uint32_t POD_PREFIX_0 = 0;
 volatile const uint32_t POD_PREFIX_1 = 0;
 volatile const uint32_t POD_PREFIX_2 = 0;
 volatile const uint32_t POD_PREFIX_3 = 0;
+
 volatile const uint32_t POD_MASK_0 = 0;
 volatile const uint32_t POD_MASK_1 = 0;
 volatile const uint32_t POD_MASK_2 = 0;


### PR DESCRIPTION
changes:
* add `make release` required by cloudbuild job for image building
* actually use nat-v4-cidr value from flags instead of using hardcoded value
* actually use nat-v6-cidr value from flags instead of using hardcoded value
* update README to remove yaml for kind cluster, since we have it in kind-ipv6.yaml
* update README install instructions to use image tag built from `make image-build`