### PR TITLE
Do not build locally for releasing the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ image-push:
 		--push
 
 .PHONY: release # Build a multi-arch docker image
-release: build image-push
+release: image-push


### PR DESCRIPTION
The building happens inside the container defined by the Dockerfile so no need to build locally.

It also solves the failure of the job promoting the image

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-nat64-image/1901638113793413120