### PR TITLE
Raise Go and kind versions

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.25"
   K8S_VERSION: "v1.32.0"
-  KIND_VERSION: "v0.26.0"
+  KIND_VERSION: "v0.31.0"
   REGISTRY: registry.k8s.io
   IMAGE_NAME: networking/nat64
   KIND_CLUSTER_NAME: kind

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.25"
   K8S_VERSION: "v1.32.0"
-  KIND_VERSION: "v0.26.0"
+  KIND_VERSION: "v0.31.0"
   REGISTRY: registry.k8s.io
   IMAGE_NAME: networking/nat64
   KIND_CLUSTER_NAME: kind

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/nat64
 
-go 1.23.0
+go 1.25.6
 
 require (
 	github.com/cilium/ebpf v0.13.0

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -7,4 +7,4 @@ set -o pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 cd $REPO_ROOT
-docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.0.2 golangci-lint run -v
+docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.8.0 golangci-lint run -v


### PR DESCRIPTION
Raises Go version to 1.25 to match current release and allow picking up latest k8s libraries. Also raises kind to 0.31.0 for the latest version.

Also bumps golangci-lint to the latest version to support the newer version of Go.