### PR TITLE
Use k8s debian-base instead of Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG GOARCH="amd64"
 
-FROM ubuntu:24.04 AS ebpf-builder
+FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.6 AS ebpf-builder
 WORKDIR /go/src/app
 RUN apt-get update && apt-get -y install clang llvm
 COPY ./bpf ./bpf


### PR DESCRIPTION
This is the same as most k8s repos use.